### PR TITLE
Update version to 5.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fcrepo-audit</artifactId>
@@ -68,17 +68,17 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-kernel-api</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-kernel-modeshape</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-mint</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.modeshape</groupId>


### PR DESCRIPTION

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2575

# What does this Pull Request do?
Just bumps the version of fcrepo-audit to `5.0.0-SNAPSHOT`

# What's new?
Development on master breaks the 5.0.0 threshold, and invites breaking API changes.

# How should this be tested?

* Build Fedora `5.0.0-SNAPSHOT` via `mvn clean install`
* Build `fcrepo-mint` `5.0.0-SNAPSHOT` via `mvn clean install`
* Build `fcrepo-audit` via `mvn clean install`.
* Check artifacts in `~/.m2/repository/org/fcrepo` for anything untoward

# Interested parties
@fcrepo4/committers
