### PR TITLE
Adds deprecation warnings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ fcrepo-audit
 
 
 Provides audit functionality for the Fedora Commons repository framework. The [fcrepo-webapp-plus](https://github.com/fcrepo4-exts/fcrepo-webapp-plus) project provides a convenient option to build fcrepo-webapp packaged with fcrepo-audit module.
+This functionality has been deprecated as of v.4.7.5.  It will no longer continue to be supported by 5.x.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ fcrepo-audit
 
 [![Build Status](https://travis-ci.org/fcrepo4-exts/fcrepo-audit.png?branch=master)](https://travis-ci.org/fcrepo4-exts/fcrepo-audit)
 
+**This functionality has been deprecated as of v.4.7.5.  It will no longer continue to be supported by 5.x.**
 
 Provides audit functionality for the Fedora Commons repository framework. The [fcrepo-webapp-plus](https://github.com/fcrepo4-exts/fcrepo-webapp-plus) project provides a convenient option to build fcrepo-webapp packaged with fcrepo-audit module.
-This functionality has been deprecated as of v.4.7.5.  It will no longer continue to be supported by 5.x.

--- a/src/main/java/org/fcrepo/audit/Auditor.java
+++ b/src/main/java/org/fcrepo/audit/Auditor.java
@@ -26,6 +26,7 @@ import com.google.common.eventbus.Subscribe;
  * 
  * @author Edwin Shin
  */
+@Deprecated
 public interface Auditor {
 
     /**

--- a/src/main/java/org/fcrepo/audit/InternalAuditor.java
+++ b/src/main/java/org/fcrepo/audit/InternalAuditor.java
@@ -74,6 +74,7 @@ import org.apache.jena.rdf.model.Statement;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import sun.util.locale.provider.LocaleServiceProviderPool;
 
 /**
  * Auditor implementation that creates audit nodes in the repository.
@@ -81,6 +82,7 @@ import com.google.common.eventbus.Subscribe;
  * @author escowles
  * @since 2015-04-15
  */
+@Deprecated
 public class InternalAuditor implements Auditor {
 
     /**
@@ -133,6 +135,8 @@ public class InternalAuditor implements Auditor {
             LOGGER.warn("Cannot Initialize: {}", this.getClass().getCanonicalName());
             LOGGER.warn("System property not found: " + AUDIT_CONTAINER);
         }
+
+        LOGGER.warn("The fcrepo-audit extension is now deprecated and will no longer be supported in Fedora 5.x.");
     }
 
     /**

--- a/src/main/java/org/fcrepo/audit/InternalAuditor.java
+++ b/src/main/java/org/fcrepo/audit/InternalAuditor.java
@@ -74,7 +74,6 @@ import org.apache.jena.rdf.model.Statement;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-import sun.util.locale.provider.LocaleServiceProviderPool;
 
 /**
  * Auditor implementation that creates audit nodes in the repository.

--- a/src/main/java/org/fcrepo/audit/LogbackAuditor.java
+++ b/src/main/java/org/fcrepo/audit/LogbackAuditor.java
@@ -35,6 +35,7 @@ import com.google.common.eventbus.Subscribe;
  * @author Edwin Shin
  * @since 2014
  */
+@Deprecated
 public class LogbackAuditor implements Auditor {
 
     /**
@@ -52,6 +53,7 @@ public class LogbackAuditor implements Auditor {
     public void register() {
         LOGGER.debug("Initializing: {}", this.getClass().getCanonicalName());
         eventBus.register(this);
+        LOGGER.warn("The fcrepo-audit extension is now deprecated and will no longer be supported in Fedora 5.x.");
     }
 
     @Override


### PR DESCRIPTION
fcrepo-audit will be discontinued with the  5.0 release.

Resolves: https://jira.duraspace.org/browse/FCREPO-2660